### PR TITLE
Fix translation key name

### DIFF
--- a/src/data/translations.yaml
+++ b/src/data/translations.yaml
@@ -101,7 +101,7 @@ fr:
   size_original: "Originale"
   back_to_gallery: "Retourner à la galerie"
   glossary_thumbnail_alt: "Illustration de :"
-  post_footerr: Pied de page de l'article
+  post_footer: Pied de page de l'article
   post_featured: "Article en vedette"
   bluesky_sharing: Partager sur Bluesky
   image_gallery_title: "Galerie d'images"


### PR DESCRIPTION
## Summary
- correct typo in French translations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68404f7639d483268777cffa8e2fd677