### PR TITLE
Fix glossary keyword extraction

### DIFF
--- a/scripts/glossary_builder.py
+++ b/scripts/glossary_builder.py
@@ -63,7 +63,7 @@ class GlossaryBuilder:
                     'slug': slug,
                     'summary': metadata.get('summary', ''),
                     'categories': metadata.get('categories', []),
-                    'meta_keywords': metadata.  get('meta_keywords', []),
+                    'meta_keywords': metadata.get('meta_keywords', []),
                     'tags': metadata.get('tags', []),
 
                     'thumbnail': metadata.get('thumbnail', ''),


### PR DESCRIPTION
## Summary
- fix typo in `metadata.get()` access in glossary builder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684050e9b8bc83268feda20263d4b37b